### PR TITLE
Extract exit-point detection into separate module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ It is also important that the normal dev build also works because it runs import
 - `source/` — plugin implementation
   - `plugin.cpp` — `CorePluginInit` entry point (registers RenderLayer)
   - `ui_plugin.cpp` — `UIPluginInit` entry point (color picker, only with Qt6)
+  - `ExitPointDetection.cpp` — exit-point detection (return/tailcall/noreturn)
   - `ReturnHighlightRenderLayer.cpp` — core highlight logic
   - `ColorPickerAction.cpp` — Qt color picker UI
 - `include/BinjaReturnHighlighter/` — public headers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(BinjaReturnHighlighter::core ALIAS BinjaReturnHighlighter_core)
 target_sources(
     BinjaReturnHighlighter_core
     PRIVATE
+        source/ExitPointDetection.cpp
         source/ReturnHighlightRenderLayer.cpp
 
     PUBLIC
@@ -31,6 +32,7 @@ target_sources(
     BASE_DIRS include
     FILES
         include/BinjaReturnHighlighter/ColorDefs.hpp
+        include/BinjaReturnHighlighter/ExitPointDetection.hpp
         include/BinjaReturnHighlighter/ReturnHighlightRenderLayer.hpp
 )
 

--- a/include/BinjaReturnHighlighter/ExitPointDetection.hpp
+++ b/include/BinjaReturnHighlighter/ExitPointDetection.hpp
@@ -1,6 +1,10 @@
 #ifndef EXITPOINTDETECTION_HPP
 #define EXITPOINTDETECTION_HPP
 
+#include <cstdint>
+#include <unordered_set>
+
+#include <binaryninjaapi.h>
 #include <highlevelilinstruction.h>
 #include <lowlevelilinstruction.h>
 #include <mediumlevelilinstruction.h>
@@ -8,5 +12,8 @@
 bool LlilInstructionIsExitPoint(const BinaryNinja::LowLevelILInstruction& instruction);
 bool MlilInstructionIsExitPoint(const BinaryNinja::MediumLevelILInstruction& instruction);
 bool HlilInstructionIsExitPoint(const BinaryNinja::HighLevelILInstruction& instruction);
+
+std::unordered_set<uint64_t> FindExitPointAddresses(
+	const BinaryNinja::Ref<BinaryNinja::Function>& func, uint64_t blockStart, uint64_t blockEnd);
 
 #endif  // EXITPOINTDETECTION_HPP

--- a/include/BinjaReturnHighlighter/ExitPointDetection.hpp
+++ b/include/BinjaReturnHighlighter/ExitPointDetection.hpp
@@ -1,0 +1,12 @@
+#ifndef EXITPOINTDETECTION_HPP
+#define EXITPOINTDETECTION_HPP
+
+#include <highlevelilinstruction.h>
+#include <lowlevelilinstruction.h>
+#include <mediumlevelilinstruction.h>
+
+bool LlilInstructionIsExitPoint(const BinaryNinja::LowLevelILInstruction& instruction);
+bool MlilInstructionIsExitPoint(const BinaryNinja::MediumLevelILInstruction& instruction);
+bool HlilInstructionIsExitPoint(const BinaryNinja::HighLevelILInstruction& instruction);
+
+#endif  // EXITPOINTDETECTION_HPP

--- a/source/ExitPointDetection.cpp
+++ b/source/ExitPointDetection.cpp
@@ -1,7 +1,9 @@
 #include "BinjaReturnHighlighter/ExitPointDetection.hpp"
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
+#include <unordered_set>
 
 #include <binaryninjaapi.h>
 #include <binaryninjacore.h>
@@ -54,4 +56,38 @@ bool MlilInstructionIsExitPoint(const MediumLevelILInstruction& instruction)
 bool HlilInstructionIsExitPoint(const HighLevelILInstruction& instruction)
 {
 	return InstructionIsExitPoint<HLIL_RET, HLIL_TAILCALL, HLIL_NORET, HLIL_CONST_PTR, HLIL_CALL>(instruction);
+}
+
+std::unordered_set<uint64_t> FindExitPointAddresses(const Ref<Function>& func, uint64_t blockStart, uint64_t blockEnd)
+{
+	std::unordered_set<uint64_t> exitAddrs;
+	auto llil = func->GetLowLevelIL();
+	if (!llil)
+	{
+		return exitAddrs;
+	}
+	for (const auto& llilBlock : llil->GetBasicBlocks())
+	{
+		const size_t llilStart = llilBlock->GetStart();
+		const size_t llilEnd = llilBlock->GetEnd();
+		if (llilStart >= llilEnd)
+		{
+			continue;
+		}
+		const uint64_t firstAddr = llil->GetInstruction(llilStart).address;
+		const uint64_t lastAddr = llil->GetInstruction(llilEnd - 1).address;
+		if (lastAddr < blockStart || firstAddr >= blockEnd)
+		{
+			continue;
+		}
+		for (size_t i = llilStart; i < llilEnd; i++)
+		{
+			auto instr = llil->GetInstruction(i);
+			if (instr.address >= blockStart && instr.address < blockEnd && LlilInstructionIsExitPoint(instr))
+			{
+				exitAddrs.insert(instr.address);
+			}
+		}
+	}
+	return exitAddrs;
 }

--- a/source/ExitPointDetection.cpp
+++ b/source/ExitPointDetection.cpp
@@ -1,0 +1,57 @@
+#include "BinjaReturnHighlighter/ExitPointDetection.hpp"
+
+#include <algorithm>
+#include <cstdint>
+
+#include <binaryninjaapi.h>
+#include <binaryninjacore.h>
+
+using namespace BinaryNinja;
+
+namespace {
+	bool IsNoreturnCallDest(uint64_t destAddr, const Ref<Function>& caller)
+	{
+		auto view = caller->GetView();
+		return std::ranges::any_of(view->GetAnalysisFunctionsForAddress(destAddr), [](const Ref<Function>& target) {
+			return !target->CanReturn().GetValue();
+		});
+	}
+
+	template <auto RetOp, auto TailcallOp, auto NoretOp, auto ConstPtrOp, auto... CallOps>
+	bool InstructionIsExitPoint(const auto& instruction)
+	{
+		const auto operation = instruction.operation;
+		if (operation == RetOp || operation == TailcallOp || operation == NoretOp)
+		{
+			return true;
+		}
+		if (((operation == CallOps) || ...))
+		{
+			auto dest = instruction.GetDestExpr();
+			if (dest.operation == ConstPtrOp)
+			{
+				if (IsNoreturnCallDest(static_cast<uint64_t>(dest.GetConstant()), instruction.function->GetFunction()))
+				{
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+}  // namespace
+
+bool LlilInstructionIsExitPoint(const LowLevelILInstruction& instruction)
+{
+	return InstructionIsExitPoint<LLIL_RET, LLIL_TAILCALL, LLIL_NORET, LLIL_CONST_PTR, LLIL_CALL>(instruction);
+}
+
+bool MlilInstructionIsExitPoint(const MediumLevelILInstruction& instruction)
+{
+	return InstructionIsExitPoint<MLIL_RET, MLIL_TAILCALL, MLIL_NORET, MLIL_CONST_PTR, MLIL_CALL, MLIL_CALL_UNTYPED>(
+		instruction);
+}
+
+bool HlilInstructionIsExitPoint(const HighLevelILInstruction& instruction)
+{
+	return InstructionIsExitPoint<HLIL_RET, HLIL_TAILCALL, HLIL_NORET, HLIL_CONST_PTR, HLIL_CALL>(instruction);
+}

--- a/source/ReturnHighlightRenderLayer.cpp
+++ b/source/ReturnHighlightRenderLayer.cpp
@@ -4,7 +4,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <optional>
-#include <unordered_set>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -184,39 +183,8 @@ void ReturnHighlightRenderLayer::ApplyToDisassemblyBlock(Ref<BasicBlock> block, 
 	{
 		return;
 	}
-	auto llil = func->GetLowLevelIL();
-	if (!llil)
-	{
-		return;
-	}
 
-	const uint64_t blockStart = block->GetStart();
-	const uint64_t blockEnd = block->GetEnd();
-	std::unordered_set<uint64_t> exitAddrs;
-	for (const auto& llilBlock : llil->GetBasicBlocks())
-	{
-		const size_t llilStart = llilBlock->GetStart();
-		const size_t llilEnd = llilBlock->GetEnd();
-		if (llilStart >= llilEnd)
-		{
-			continue;
-		}
-		const uint64_t firstAddr = llil->GetInstruction(llilStart).address;
-		const uint64_t lastAddr = llil->GetInstruction(llilEnd - 1).address;
-		if (lastAddr < blockStart || firstAddr >= blockEnd)
-		{
-			continue;
-		}
-		for (size_t i = llilStart; i < llilEnd; i++)
-		{
-			auto instr = llil->GetInstruction(i);
-			if (instr.address >= blockStart && instr.address < blockEnd && LlilInstructionIsExitPoint(instr))
-			{
-				exitAddrs.insert(instr.address);
-			}
-		}
-	}
-
+	const auto exitAddrs = FindExitPointAddresses(func, block->GetStart(), block->GetEnd());
 	for (auto& line : lines)
 	{
 		if (exitAddrs.contains(line.addr))

--- a/source/ReturnHighlightRenderLayer.cpp
+++ b/source/ReturnHighlightRenderLayer.cpp
@@ -13,9 +13,7 @@
 #include <binaryninjacore.h>
 
 #include "BinjaReturnHighlighter/ColorDefs.hpp"
-#include <highlevelilinstruction.h>
-#include <lowlevelilinstruction.h>
-#include <mediumlevelilinstruction.h>
+#include "BinjaReturnHighlighter/ExitPointDetection.hpp"
 
 using namespace BinaryNinja;
 
@@ -111,52 +109,6 @@ namespace {
 			.g = green,
 			.b = blue,
 			.alpha = AlphaSolid};
-	}
-
-	bool IsNoreturnCallDest(uint64_t destAddr, const Ref<Function>& caller)
-	{
-		auto view = caller->GetView();
-		return std::ranges::any_of(view->GetAnalysisFunctionsForAddress(destAddr), [](const Ref<Function>& target) {
-			return !target->CanReturn().GetValue();
-		});
-	}
-
-	template <auto RetOp, auto TailcallOp, auto NoretOp, auto ConstPtrOp, auto... CallOps>
-	bool InstructionIsExitPoint(const auto& instruction)
-	{
-		const auto operation = instruction.operation;
-		if (operation == RetOp || operation == TailcallOp || operation == NoretOp)
-		{
-			return true;
-		}
-		if (((operation == CallOps) || ...))
-		{
-			auto dest = instruction.GetDestExpr();
-			if (dest.operation == ConstPtrOp)
-			{
-				if (IsNoreturnCallDest(static_cast<uint64_t>(dest.GetConstant()), instruction.function->GetFunction()))
-				{
-					return true;
-				}
-			}
-		}
-		return false;
-	}
-
-	bool LlilInstructionIsExitPoint(const LowLevelILInstruction& instruction)
-	{
-		return InstructionIsExitPoint<LLIL_RET, LLIL_TAILCALL, LLIL_NORET, LLIL_CONST_PTR, LLIL_CALL>(instruction);
-	}
-
-	bool MlilInstructionIsExitPoint(const MediumLevelILInstruction& instruction)
-	{
-		return InstructionIsExitPoint<MLIL_RET, MLIL_TAILCALL, MLIL_NORET, MLIL_CONST_PTR, MLIL_CALL,
-			MLIL_CALL_UNTYPED>(instruction);
-	}
-
-	bool HlilInstructionIsExitPoint(const HighLevelILInstruction& instruction)
-	{
-		return InstructionIsExitPoint<HLIL_RET, HLIL_TAILCALL, HLIL_NORET, HLIL_CONST_PTR, HLIL_CALL>(instruction);
 	}
 
 	bool LineContainsKeywordToken(const DisassemblyTextLine& line)


### PR DESCRIPTION
## Summary

- Move exit-point detection logic (return/tailcall/noreturn checks) from `ReturnHighlightRenderLayer.cpp` into new `ExitPointDetection.{hpp,cpp}` files
- Extract `FindExitPointAddresses()` for disassembly-level exit-point address collection
- Separates analysis logic from render layer concerns, making exit-point detection independently testable
- No functional changes — color resolution and line processing helpers remain in the render layer

## Test plan

- [x] `cmake --build build` — dev build with clang-tidy + cppcheck passes
- [x] `cmake --build build-asan && cd build-asan && ctest` — all tests pass under ASan

🤖 Generated with [Claude Code](https://claude.com/claude-code)