### PR TITLE
Code quality and consistency improvements

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,6 +16,7 @@ Checks: "*,\
   -llvm-include-order,\
   -llvm-prefer-static-over-anonymous-namespace,\
   -llvmlibc-*,\
+  -portability-avoid-pragma-once,\
   -modernize-use-nodiscard,\
   -modernize-use-trailing-return-type,\
   -misc-non-private-member-variables-in-classes"

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -19,7 +19,7 @@ Checks: "*,\
   -modernize-use-nodiscard,\
   -modernize-use-trailing-return-type,\
   -misc-non-private-member-variables-in-classes"
-WarningsAsErrors: ''
+WarningsAsErrors: '*'
 CheckOptions:
   - key: 'bugprone-argument-comment.StrictMode'
     value: 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ include(cmake/variables.cmake)
 
 add_subdirectory(external)
 
-# fmt is included as an example vcpkg dependency for template adopters
+# fmt is used for string formatting in log messages
 find_package(fmt REQUIRED)
 
 # ---- Core object library (shared between plugin and tests) ----

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -25,7 +25,7 @@ Create a `CMakeUserPresets.json` file (not versioned) with local development pre
       },
       "cacheVariables": {
         "BN_QT_DIR": "<path-to-qt>",
-        "CMAKE_CXX_CLANG_TIDY": "<path-to-clang-tidy>;-warnings-as-errors=*",
+        "CMAKE_CXX_CLANG_TIDY": "<path-to-clang-tidy>",
         "CMAKE_CXX_CPPCHECK": "cppcheck",
         "CMAKE_OSX_ARCHITECTURES": null,
         "CMAKE_BUILD_TYPE": "RelWithDebInfo"

--- a/cmake/lint-targets.cmake
+++ b/cmake/lint-targets.cmake
@@ -32,8 +32,8 @@ add_custom_target(
     VERBATIM
 )
 
-# Extract clang-tidy path from CMAKE_CXX_CLANG_TIDY (first element is the binary,
-# rest are flags like -warnings-as-errors=*) for consistency with build-time checks.
+# Extract clang-tidy path from CMAKE_CXX_CLANG_TIDY (first element is the binary)
+# for consistency with build-time checks.
 if(CMAKE_CXX_CLANG_TIDY)
   list(GET CMAKE_CXX_CLANG_TIDY 0 _tidy_default)
 else()

--- a/include/BinjaReturnHighlighter/ColorDefs.hpp
+++ b/include/BinjaReturnHighlighter/ColorDefs.hpp
@@ -1,5 +1,4 @@
-#ifndef COLORDEFS_HPP
-#define COLORDEFS_HPP
+#pragma once
 
 #include <array>
 #include <cstdint>
@@ -37,5 +36,3 @@ constexpr const ColorDef* FindColorByName(std::string_view name)
 	}
 	return nullptr;
 }
-
-#endif  // COLORDEFS_HPP

--- a/include/BinjaReturnHighlighter/ColorDefs.hpp
+++ b/include/BinjaReturnHighlighter/ColorDefs.hpp
@@ -3,7 +3,6 @@
 
 #include <array>
 #include <cstdint>
-#include <optional>
 #include <string_view>
 
 #include <binaryninjacore.h>
@@ -27,7 +26,7 @@ constexpr std::array<ColorDef, 9> ColorDefs = {{
 	{.name = "black", .r = 0, .g = 0, .b = 0, .bnColor = BlackHighlightColor},
 }};
 
-constexpr std::optional<const ColorDef*> FindColorByName(std::string_view name)
+constexpr const ColorDef* FindColorByName(std::string_view name)
 {
 	for (const auto& def : ColorDefs)
 	{
@@ -36,7 +35,7 @@ constexpr std::optional<const ColorDef*> FindColorByName(std::string_view name)
 			return &def;
 		}
 	}
-	return std::nullopt;
+	return nullptr;
 }
 
 #endif  // COLORDEFS_HPP

--- a/include/BinjaReturnHighlighter/ColorPickerAction.hpp
+++ b/include/BinjaReturnHighlighter/ColorPickerAction.hpp
@@ -1,6 +1,3 @@
-#ifndef COLORPICKERACTION_HPP
-#define COLORPICKERACTION_HPP
+#pragma once
 
 void RegisterColorPickerAction();
-
-#endif  // COLORPICKERACTION_HPP

--- a/include/BinjaReturnHighlighter/ExitPointDetection.hpp
+++ b/include/BinjaReturnHighlighter/ExitPointDetection.hpp
@@ -1,5 +1,4 @@
-#ifndef EXITPOINTDETECTION_HPP
-#define EXITPOINTDETECTION_HPP
+#pragma once
 
 #include <cstdint>
 #include <unordered_set>
@@ -15,5 +14,3 @@ bool HlilInstructionIsExitPoint(const BinaryNinja::HighLevelILInstruction& instr
 
 std::unordered_set<uint64_t> FindExitPointAddresses(
 	const BinaryNinja::Ref<BinaryNinja::Function>& func, uint64_t blockStart, uint64_t blockEnd);
-
-#endif  // EXITPOINTDETECTION_HPP

--- a/include/BinjaReturnHighlighter/ReturnHighlightRenderLayer.hpp
+++ b/include/BinjaReturnHighlighter/ReturnHighlightRenderLayer.hpp
@@ -12,7 +12,7 @@ class ReturnHighlightRenderLayer final : public BinaryNinja::RenderLayer
 {
 	BinaryNinja::Ref<BinaryNinja::Logger> m_logger;
 	mutable std::string m_cachedColorSetting;
-	mutable BNHighlightColor m_cachedHighlight;
+	mutable BNHighlightColor m_cachedHighlight;  // Zero-init = no highlight until first valid setting
 
 	BNHighlightColor ResolveHighlightColor() const;
 

--- a/include/BinjaReturnHighlighter/ReturnHighlightRenderLayer.hpp
+++ b/include/BinjaReturnHighlighter/ReturnHighlightRenderLayer.hpp
@@ -1,5 +1,4 @@
-#ifndef RETURNHIGHLIGHTRENDERLAYER_HPP
-#define RETURNHIGHLIGHTRENDERLAYER_HPP
+#pragma once
 
 #include <string>
 #include <vector>
@@ -35,5 +34,3 @@ public:
 	void ApplyToHighLevelILBody(BinaryNinja::Ref<BinaryNinja::Function> function,
 		std::vector<BinaryNinja::LinearDisassemblyLine>& lines) override;
 };
-
-#endif  // RETURNHIGHLIGHTRENDERLAYER_HPP

--- a/prek.toml
+++ b/prek.toml
@@ -28,7 +28,7 @@ id = "build-dev"
 name = "Build (dev preset)"
 entry = "bash -c 'cmake --preset dev && cmake --build build'"
 language = "system"
-stages = ["pre-push"]
+stages = ["pre-commit"]
 always_run = true
 pass_filenames = false
 
@@ -37,6 +37,6 @@ id = "build-test-asan"
 name = "Build and test (asan preset)"
 entry = "bash -c 'cmake --preset asan && cmake --build build-asan && ctest --test-dir build-asan --output-on-failure'"
 language = "system"
-stages = ["pre-push"]
+stages = ["pre-commit"]
 always_run = true
 pass_filenames = false

--- a/source/ColorPickerAction.cpp
+++ b/source/ColorPickerAction.cpp
@@ -21,9 +21,9 @@ using BinaryNinja::Settings;
 namespace {
 	QColor NameToQColor(const std::string& name)
 	{
-		if (auto def = FindColorByName(name))
+		if (const auto* def = FindColorByName(name))
 		{
-			return {(*def)->r, (*def)->g, (*def)->b};
+			return {def->r, def->g, def->b};
 		}
 		const auto& fallback = ColorDefs.front();
 		return {fallback.r, fallback.g, fallback.b};

--- a/source/ColorPickerAction.cpp
+++ b/source/ColorPickerAction.cpp
@@ -55,6 +55,13 @@ void RegisterColorPickerAction()
 	UIAction::registerAction(actionName);
 
 	UIActionHandler::globalActions()->bindAction(actionName, UIAction([] {
+		auto refreshView = [] {
+			if (auto* ctx = UIContext::activeContext())
+			{
+				ctx->refreshCurrentViewContents();
+			}
+		};
+
 		QWidget* parent = nullptr;
 		UIContext* ctx = UIContext::activeContext();
 		if (ctx != nullptr)
@@ -69,16 +76,12 @@ void RegisterColorPickerAction()
 		dialog.setWindowTitle("Return Highlighter Color");
 		dialog.setOption(QColorDialog::DontUseNativeDialog);
 
-		QObject::connect(&dialog, &QColorDialog::currentColorChanged, [](const QColor& color) {
+		QObject::connect(&dialog, &QColorDialog::currentColorChanged, [&refreshView](const QColor& color) {
 			if (color.isValid())
 			{
 				const std::string hex = color.name().toStdString();
 				Settings::Instance()->Set("returnHighlighter.highlightColor", hex);
-
-				if (UIContext* activeCtx = UIContext::activeContext())
-				{
-					activeCtx->refreshCurrentViewContents();
-				}
+				refreshView();
 			}
 		});
 
@@ -97,10 +100,7 @@ void RegisterColorPickerAction()
 			Settings::Instance()->Set("returnHighlighter.highlightColor", originalSetting);
 		}
 
-		if (UIContext* activeCtx = UIContext::activeContext())
-		{
-			activeCtx->refreshCurrentViewContents();
-		}
+		refreshView();
 	}));
 
 	Menu::mainMenu("Plugins")->addAction(actionName, "Choose Color");

--- a/source/ExitPointDetection.cpp
+++ b/source/ExitPointDetection.cpp
@@ -11,6 +11,12 @@
 using namespace BinaryNinja;
 
 namespace {
+	template <typename T>
+	concept ILInstruction = requires(T instr) {
+		instr.operation;
+		instr.GetDestExpr();
+	};
+
 	bool IsNoreturnCallDest(uint64_t destAddr, const Ref<Function>& caller)
 	{
 		auto view = caller->GetView();
@@ -20,7 +26,7 @@ namespace {
 	}
 
 	template <auto RetOp, auto TailcallOp, auto NoretOp, auto ConstPtrOp, auto... CallOps>
-	bool InstructionIsExitPoint(const auto& instruction)
+	bool InstructionIsExitPoint(const ILInstruction auto& instruction)
 	{
 		const auto operation = instruction.operation;
 		if (operation == RetOp || operation == TailcallOp || operation == NoretOp)

--- a/source/ReturnHighlightRenderLayer.cpp
+++ b/source/ReturnHighlightRenderLayer.cpp
@@ -172,7 +172,8 @@ BNHighlightColor ReturnHighlightRenderLayer::ResolveHighlightColor() const
 	return m_cachedHighlight;
 }
 
-void ReturnHighlightRenderLayer::ApplyToDisassemblyBlock(Ref<BasicBlock> block, std::vector<DisassemblyTextLine>& lines)
+void ReturnHighlightRenderLayer::ApplyToDisassemblyBlock(
+	const Ref<BasicBlock> block, std::vector<DisassemblyTextLine>& lines)
 {
 	const BNHighlightColor highlight = ResolveHighlightColor();
 	auto func = block->GetFunction();
@@ -206,7 +207,7 @@ void ReturnHighlightRenderLayer::ApplyToMediumLevelILBlock(
 }
 
 void ReturnHighlightRenderLayer::ApplyToHighLevelILBlock(
-	Ref<BasicBlock> const block, std::vector<DisassemblyTextLine>& lines)
+	const Ref<BasicBlock> block, std::vector<DisassemblyTextLine>& lines)
 {
 	const BNHighlightColor highlight = ResolveHighlightColor();
 	HighlightExitPointLines(highlight, block->GetHighLevelILFunction(), lines, HlilInstructionIsExitPoint);

--- a/source/ReturnHighlightRenderLayer.cpp
+++ b/source/ReturnHighlightRenderLayer.cpp
@@ -3,9 +3,11 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <charconv>
 #include <optional>
-#include <stdexcept>
 #include <string>
+#include <string_view>
+#include <system_error>
 #include <vector>
 
 #include <binaryninjaapi.h>
@@ -48,27 +50,22 @@ namespace {
 	constexpr uint32_t ByteMask = 0xFF;
 	constexpr int HexBase = 16;
 
-	std::optional<RgbColor> ParseHexColor(const std::string& str)
+	std::optional<RgbColor> ParseHexColor(std::string_view str)
 	{
-		std::string hex = str;
-		if (!hex.empty() && hex.front() == '#')
+		if (!str.empty() && str.front() == '#')
 		{
-			hex = hex.substr(1);
+			str.remove_prefix(1);
 		}
-		if (hex.size() != HexColorLen)
+		if (str.size() != HexColorLen)
 		{
 			return std::nullopt;
 		}
 		uint32_t val = 0;
-		try
-		{
-			val = static_cast<uint32_t>(std::stoul(hex, nullptr, HexBase));
-		}
-		catch (const std::invalid_argument&)
-		{
-			return std::nullopt;
-		}
-		catch (const std::out_of_range&)
+		// std::from_chars requires raw pointers; this is bounded access on a string_view
+		// NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+		auto [ptr, ec] = std::from_chars(str.data(), str.data() + str.size(), val, HexBase);
+		// NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+		if (ec != std::errc {} || ptr != str.data() + str.size())
 		{
 			return std::nullopt;
 		}
@@ -77,7 +74,7 @@ namespace {
 			.b = static_cast<uint8_t>(val & ByteMask)};
 	}
 
-	std::optional<BNHighlightStandardColor> MapColorName(const std::string& name)
+	std::optional<BNHighlightStandardColor> MapColorName(std::string_view name)
 	{
 		if (const auto* def = FindColorByName(name))
 		{

--- a/source/ReturnHighlightRenderLayer.cpp
+++ b/source/ReturnHighlightRenderLayer.cpp
@@ -79,9 +79,9 @@ namespace {
 
 	std::optional<BNHighlightStandardColor> MapColorName(const std::string& name)
 	{
-		if (auto def = FindColorByName(name))
+		if (const auto* def = FindColorByName(name))
 		{
-			return (*def)->bnColor;
+			return def->bnColor;
 		}
 		return std::nullopt;
 	}

--- a/test/TestHelpers.hpp
+++ b/test/TestHelpers.hpp
@@ -1,5 +1,4 @@
-#ifndef TESTHELPERS_HPP
-#define TESTHELPERS_HPP
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -47,5 +46,3 @@ namespace TestHelpers {
 	};
 
 }  // namespace TestHelpers
-
-#endif  // TESTHELPERS_HPP


### PR DESCRIPTION
## Summary

- Move prek hooks from pre-push to pre-commit so every commit is build+test verified
- Promote all clang-tidy warnings to errors via `.clang-tidy` config instead of CLI flags
- Simplify `FindColorByName` to return plain pointer instead of `std::optional<const ColorDef*>`
- Replace `std::stoul` + try/catch with `std::from_chars` in hex color parsing
- Normalize `const Ref<BasicBlock>` placement across render layer methods
- Fix misleading CMake comment about fmt dependency
- Replace header guards with `#pragma once` in all project headers
- Extract duplicated view-refresh logic into a lambda in the color picker
- Add C++20 `ILInstruction` concept to constrain IL template parameter
- Document zero-init fallback behavior of `m_cachedHighlight`

Each commit builds and passes tests independently (enforced by pre-commit hooks).

## Test plan

- [x] All 10 commits pass `cmake --preset dev && cmake --build build` (clang-tidy + cppcheck)
- [x] All 10 commits pass `cmake --preset asan && cmake --build build-asan && ctest --test-dir build-asan`
- [x] Plugin installs and loads in Binary Ninja

🤖 Generated with [Claude Code](https://claude.com/claude-code)